### PR TITLE
Update and improve debian/copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,9 +1,26 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Cinnamon translations
+Upstream-Contact: Linux Mint Project <root@linuxmint.com>
+Source: https://github.com/linuxmint/cinnamon-translations
 
-License:
+Files: *
+Copyright: Clement Lefebvre
+License: GPL-2+
 
-   This package is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License version 2 as published by
-   the Free Software Foundation.
-
-The Debian packaging is (C) 2013, Clement Lefebvre <root@linuxmint.com> and
-is licensed under the GPLv2, see above.
+License: GPL-2+
+ This package is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this package; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License can be found in `/usr/share/common-licenses/GPL-2'.


### PR DESCRIPTION
- Use gplv2+ license, same of the projects that generate locale files.
- Following debian standard copyright format
