### PR TITLE
Fix a small error in Nemo's German copy dialog

### DIFF
--- a/po-export/nemo/nemo-de.po
+++ b/po-export/nemo/nemo-de.po
@@ -4346,7 +4346,7 @@ msgstr "Datei %'d von %'d wird nach »%B« verschoben"
 
 #: libnemo-private/nemo-file-operations.c:3105
 msgid "Copying file %'d of %'d to \"%B\""
-msgstr "Datei %'d wird von %'d nach »%B« kopiert"
+msgstr "Datei %'d von %'d wird nach »%B« kopiert"
 
 #: libnemo-private/nemo-file-operations.c:3111
 #, c-format


### PR DESCRIPTION
Just fixed a small translation error that bugged me for a while.