### PR TITLE
more accurate german translation of "uninstal"l and weird dots

### DIFF
--- a/po-export/cinnamon/cinnamon-de.po
+++ b/po-export/cinnamon/cinnamon-de.po
@@ -85,11 +85,11 @@ msgstr "Dieses Applet entfernen"
 
 #: js/ui/applet.js:413 js/ui/desklet.js:219
 msgid "About..."
-msgstr "Über …"
+msgstr "Über ..."
 
 #: js/ui/applet.js:433 js/ui/desklet.js:224
 msgid "Configure..."
-msgstr "Einrichten …"
+msgstr "Einrichten ..."
 
 #: js/ui/appletManager.js:559
 msgid "Certain applets do not allow multiple instances and were not copied"
@@ -590,7 +590,7 @@ msgstr "Zu den Favoriten hinzufügen"
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:248
 #: files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py:648
 msgid "Uninstall"
-msgstr "Entfernen"
+msgstr "Deinstallieren"
 
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:621
 msgid "Open with"
@@ -598,7 +598,7 @@ msgstr "Öffnen mit"
 
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:667
 msgid "Other application..."
-msgstr "Andere Anwendung …"
+msgstr "Andere Anwendung ..."
 
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:734
 #: files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js:91
@@ -657,7 +657,7 @@ msgstr "Den Rechner herunterfahren"
 
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:2205
 msgid "Type to search..."
-msgstr "Suchbegriff eingeben …"
+msgstr "Suchbegriff eingeben ..."
 
 #: files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js:95
 msgid "<unknown>"
@@ -673,11 +673,11 @@ msgstr "nicht verwaltet"
 
 #: files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js:510
 msgid "disconnecting..."
-msgstr "Verbindung wird getrennt …"
+msgstr "Verbindung wird getrennt ..."
 
 #: files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js:516
 msgid "connecting..."
-msgstr "Verbindung wird aufgebaut …"
+msgstr "Verbindung wird aufgebaut ..."
 
 #: files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js:519
 msgid "authentication required"
@@ -1317,15 +1317,15 @@ msgstr "Gastsitzung"
 
 #: files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js:129
 msgid "Log Out..."
-msgstr "Abmelden …"
+msgstr "Abmelden ..."
 
 #: files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js:137
 msgid "Power Off..."
-msgstr "Ausschalten …"
+msgstr "Ausschalten ..."
 
 #: files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:671
 msgid "Configure the window list"
-msgstr "Fensterliste konfigurieren …"
+msgstr "Fensterliste konfigurieren ..."
 
 #: files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:683
 msgid "Move to the other monitor"
@@ -1395,7 +1395,7 @@ msgstr "Bildschirm"
 
 #: files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js:82
 msgid "Configure display settings..."
-msgstr "Bildschirmeinstellungen konfigurieren …"
+msgstr "Bildschirmeinstellungen konfigurieren ..."
 
 #: files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js:21
 msgid "Clock"
@@ -1740,7 +1740,7 @@ msgstr "Auf das Bild klicken um es zu ändern"
 #: files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py:485
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py:45
 msgid "Browse for more pictures..."
-msgstr "Nach weiteren Bildern suchen …"
+msgstr "Nach weiteren Bildern suchen ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py:521
 msgid "Click to change the name"
@@ -1961,7 +1961,7 @@ msgstr "Liste aktualisieren"
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py:518
 msgid "Cannot be uninstalled"
-msgstr "Kann nicht entfernt werden"
+msgstr "Kann nicht deinstalliert werden"
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py:526
 msgid "In use"
@@ -2192,11 +2192,11 @@ msgstr "Anwählen und schliessen"
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:299
 msgid "Refreshing index..."
-msgstr "Verzeichnis wird aufgefrischt …"
+msgstr "Verzeichnis wird aufgefrischt ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:319
 msgid "Refreshing cache..."
-msgstr "Zwischenspeicher wird aufgefrischt …"
+msgstr "Zwischenspeicher wird aufgefrischt ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:332
 msgid ""
@@ -2209,13 +2209,13 @@ msgstr ""
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:478
 #, python-format
 msgid "Installing translations for %s..."
-msgstr "Übersetzungen für %s werden installiert …"
+msgstr "Übersetzungen für %s werden installiert ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:482
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:576
 #, python-format
 msgid "Installing %s..."
-msgstr "%s wird installiert …"
+msgstr "%s wird installiert ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:484
 #, python-format
@@ -2268,12 +2268,12 @@ msgstr ""
 #, python-format
 msgid "Problem uninstalling %s.  You may need to manually remove it."
 msgstr ""
-"Problem beim entfernen von %s. Möglicherweise müssen Sie manuell entfernen."
+"Problem beim deinstallieren von %s. Möglicherweise müssen Sie manuell entfernen."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:618
 #, python-format
 msgid "Uninstalling %s..."
-msgstr "%s wird entfernt …"
+msgstr "%s wird deinstalliert ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py:666
 msgid ""
@@ -2304,7 +2304,7 @@ msgstr "Zurück zur Liste"
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/XletSettings.py:70
 msgid "More actions..."
-msgstr "Weitere Aktionen …"
+msgstr "Weitere Aktionen ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/XletSettings.py:72
 #, python-format
@@ -3126,7 +3126,7 @@ msgstr "Programme beim Einhängen von Medien starten"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py:443
 msgid "_Other Media..."
-msgstr "_Andere Medien …"
+msgstr "_Andere Medien ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_desklets.py:8
 msgid "Manage your Cinnamon desklets"
@@ -5358,7 +5358,7 @@ msgstr "Befehl"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py:742
 msgid "Browse..."
-msgstr "Durchsuchen …"
+msgstr "Durchsuchen ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py:747
 msgid "Comment"
@@ -5382,7 +5382,7 @@ msgstr "Befehl auswählen"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py:840
 msgid "Search Applications..."
-msgstr "Anwendung suchen …"
+msgstr "Anwendung suchen ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py:874
 msgid "_Close"
@@ -5420,7 +5420,7 @@ msgstr "Mauszeiger"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py:60
 msgid "Add/remove desktop themes..."
-msgstr "Schreibtischthemen hinzufügen/entfernen …"
+msgstr "Schreibtischthemen hinzufügen/entfernen ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py:69
 msgid "Miscellaneous options"
@@ -5532,7 +5532,7 @@ msgstr "Klicken, um Ihr Bild zu ändern"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py:42
 msgid "Take a photo..."
-msgstr "Ein Foto aufnehmen …"
+msgstr "Ein Foto aufnehmen ..."
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py:70
 msgid "Click to change your name"


### PR DESCRIPTION
The more accurate german translation of "uninstall" is "deinstallieren".
The previous used translation "entfernen" means remove.

Another reason to change the translation:
If you use the menu and click the right-mouse-button on an application, which you have in your favorites list, a shutdownmenu appears with the following options:
"Add to panel"
"Add to desktop"
"Remove from favorites"
"Uninstall"

The german translation here is confusing, because germans read the following:
"Add to panel"
"Add to desktop"
"Remove from favorites"
"Remove"


P.S.: The dots ... in the translation looked different from the original dots.