### PR TITLE
Change translation for messages and notifications 

### DIFF
--- a/po-export/cinnamon/cinnamon-he.po
+++ b/po-export/cinnamon/cinnamon-he.po
@@ -790,7 +790,7 @@ msgstr "מנע פעולת יישום"
 #: files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js:65
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py:40
 msgid "Notifications"
-msgstr "התרעות"
+msgstr "הודעות"
 
 #: files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js:145
 msgid "Show Keyboard Layout"
@@ -5478,11 +5478,11 @@ msgstr "גופן של תאריך"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py:128
 msgid "Away message"
-msgstr "הודעת עזוּב"
+msgstr "מסר עזוּב"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py:130
 msgid "Show this message when the screen is locked"
-msgstr "הצג את ההודעה הזו כאשר המסך נעול"
+msgstr "הצג את המסר הזה כאשר המסך נעול"
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py:132
 msgid "This is the default message displayed on your lock screen"


### PR DESCRIPTION
For the following changes I made only few examples. They appear many times.
1. Message is not always translated to מסר, which is a precise translation. Only in few cases I agree that הודעה is better, but you'll choose.
2. Notification should be translated to הודעה.