### PR TITLE
fix german translation for Monitor scale

### DIFF
--- a/po-export/cinnamon-control-center/cinnamon-control-center-de.po
+++ b/po-export/cinnamon-control-center/cinnamon-control-center-de.po
@@ -367,7 +367,7 @@ msgstr "%.2lf Hz"
 
 #: panels/display/cc-display-settings.c:469
 msgid "Monitor scale"
-msgstr "Bildschirmscalierung"
+msgstr "Bildschirmskalierung"
 
 #: panels/display/cc-display-settings.c:473
 #: panels/display/cc-display-settings.ui.h:4


### PR DESCRIPTION
Fixed an small typo.
scale is written with `k` in German not with `c`.