### PR TITLE
fix translate by->по to by->от

### DIFF
--- a/po-export/cinnamon/cinnamon-ru.po
+++ b/po-export/cinnamon/cinnamon-ru.po
@@ -2601,7 +2601,7 @@ msgstr "Это расширение в настоящее время включ�
 #: files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py:726
 #, python-format
 msgid "by %s"
-msgstr "по %s"
+msgstr "от %s"
 
 #: files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py:298
 msgid "Configure"


### PR DESCRIPTION
Small corrects fix to translate on Russian

 * `by` to `по` its  Rusyn language translate like `cinnamon-rue.po`
 * `by` to `от` its  Russian language translate 

In Russian `по` have other mean, not `by`.  Like `I go on the road` -> `Я иду по доге`
If we need say `Cool project by Alex` or `Cool project from Alex` its equal and we translate `Клёвый проект от Алекса` (about people)


I see it in this interface
![img](https://i.ibb.co/4JBwNC2/2023-12-04-03-05-19.png)

Moreover . if  `by` no have translate and show in interface just is as `by someone` its okey, but if need transtate it need use `от` if we talk about people 

If we say `Sort by` its other, this `by` translated to `по` `Сортировать по`  correct because not about people. Context depended, all (as far as I checked) other translations is corrects.